### PR TITLE
Add FutureMed demo site

### DIFF
--- a/Pages/exam.html
+++ b/Pages/exam.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Contact - FutureMed</title>
+    <title>Exammodus - FutureMed</title>
     <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
     <header>
-        <h1>Contact</h1>
+        <h1>Exammodus</h1>
         <nav>
             <a href="../index.html">Home</a>
             <a href="training.html">Training</a>
@@ -18,8 +18,8 @@
         </nav>
     </header>
     <main>
-        <p>Email: joseph.mugwiza21@gmail.com</p>
-        <p>Je vindt mij ook op LinkedIn.</p>
+        <p>In de exammodus kun je een volledige proef afleggen met een timer en dezelfde functionaliteiten als het officiële digitale examen, inclusief een eenvoudige rekenmachine.</p>
+        <p>Deze demo bevat slechts een basisopzet. Voor een echte simulatie zijn een database en uitgebreide logica nodig.</p>
     </main>
     <footer>
         &copy; 2024 FutureMed

--- a/Pages/hobbies.html
+++ b/Pages/hobbies.html
@@ -1,16 +1,31 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="nl">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+    <title>Hobby's - FutureMed</title>
+    <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
-    <h1>Hobbies</h1>
-    <ul>
-        <li>I like playing football aka soccer</li>
-        <li>I like watching anime, especially OnePiece</li>
-        <li>I like going to the gym</li>
-    </ul>
+    <header>
+        <h1>Hobby's</h1>
+        <nav>
+            <a href="../index.html">Home</a>
+            <a href="training.html">Training</a>
+            <a href="exam.html">Exammodus</a>
+            <a href="progress.html">Voortgang</a>
+            <a href="signup.html">Aanmelden</a>
+        </nav>
+    </header>
+    <main>
+        <ul>
+            <li>Voetbal spelen</li>
+            <li>Anime kijken, vooral One Piece</li>
+            <li>Naar de fitness gaan</li>
+        </ul>
+    </main>
+    <footer>
+        &copy; 2024 FutureMed
+    </footer>
 </body>
 </html>

--- a/Pages/progress.html
+++ b/Pages/progress.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Contact - FutureMed</title>
+    <title>Voortgang - FutureMed</title>
     <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
     <header>
-        <h1>Contact</h1>
+        <h1>Voortgang</h1>
         <nav>
             <a href="../index.html">Home</a>
             <a href="training.html">Training</a>
@@ -18,8 +18,8 @@
         </nav>
     </header>
     <main>
-        <p>Email: joseph.mugwiza21@gmail.com</p>
-        <p>Je vindt mij ook op LinkedIn.</p>
+        <p>Hier kun je later je resultaten analyseren en zien op welke onderwerpen je nog moet oefenen.</p>
+        <p>Voor deze demo worden de gegevens niet bewaard.</p>
     </main>
     <footer>
         &copy; 2024 FutureMed

--- a/Pages/signup.html
+++ b/Pages/signup.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Contact - FutureMed</title>
+    <title>Aanmelden - FutureMed</title>
     <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>
     <header>
-        <h1>Contact</h1>
+        <h1>Aanmelden</h1>
         <nav>
             <a href="../index.html">Home</a>
             <a href="training.html">Training</a>
@@ -18,8 +18,14 @@
         </nav>
     </header>
     <main>
-        <p>Email: joseph.mugwiza21@gmail.com</p>
-        <p>Je vindt mij ook op LinkedIn.</p>
+        <form>
+            <label for="name">Naam:</label><br>
+            <input type="text" id="name" name="name"><br>
+            <label for="email">E-mail:</label><br>
+            <input type="email" id="email" name="email"><br>
+            <button class="button" type="submit">Registreer</button>
+        </form>
+        <p>Na registratie kun je FutureMed één week gratis proberen.</p>
     </main>
     <footer>
         &copy; 2024 FutureMed

--- a/Pages/training.html
+++ b/Pages/training.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Training - FutureMed</title>
+    <link rel="stylesheet" href="../css/style.css">
+    <script>
+        function checkAnswer() {
+            const input = document.getElementById('answer').value.trim();
+            const feedback = document.getElementById('feedback');
+            if (input === '4') {
+                feedback.textContent = 'Correct!';
+            } else {
+                feedback.textContent = 'Fout, probeer opnieuw.';
+            }
+        }
+    </script>
+</head>
+<body>
+    <header>
+        <h1>Training</h1>
+        <nav>
+            <a href="../index.html">Home</a>
+            <a href="training.html">Training</a>
+            <a href="exam.html">Exammodus</a>
+            <a href="progress.html">Voortgang</a>
+            <a href="signup.html">Aanmelden</a>
+        </nav>
+    </header>
+    <main>
+        <p>Beantwoord de vraag en krijg meteen feedback.</p>
+        <p>Wat is 2 + 2?</p>
+        <input id="answer" type="text">
+        <button onclick="checkAnswer()">Controleer</button>
+        <p id="feedback"></p>
+    </main>
+    <footer>
+        &copy; 2024 FutureMed
+    </footer>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# html-MyResume
+# FutureMed
+
+Dit project bevat een eenvoudige demowebsite voor FutureMed. Het platform is bedoeld om studenten in Vlaanderen te helpen bij de voorbereiding op het toelatingsexamen geneeskunde, tandheelkunde en diergeneeskunde. De pagina's zijn statisch en dienen als voorbeeld van hoe het uiteindelijke platform eruit kan zien.
+
+## Pagina's
+- `index.html` – startpagina met een korte introductie.
+- `Pages/training.html` – voorbeeld van een trainingsvraag met directe feedback.
+- `Pages/exam.html` – beschrijving van de exammodus.
+- `Pages/progress.html` – plaatshouder voor voortgangsrapportage.
+- `Pages/signup.html` – eenvoudig registratieformulier.
+
+De site gebruikt een eenvoudige stylesheet in `css/style.css`.
+
+Let op: er is geen backend of betalingsfunctionaliteit aanwezig. Voor een volwaardig platform heb je server-side code en een database nodig.

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,55 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f4f4f4;
+    color: #333;
+}
+header {
+    background-color: #293241;
+    color: white;
+    padding: 1rem;
+    text-align: center;
+}
+nav {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    margin-top: 1rem;
+}
+nav a {
+    color: white;
+    text-decoration: none;
+    background-color: #3d5a80;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+}
+nav a:hover {
+    background-color: #98c1d9;
+    color: #293241;
+}
+main {
+    padding: 2rem;
+    max-width: 800px;
+    margin: auto;
+    background-color: white;
+}
+footer {
+    text-align: center;
+    padding: 1rem;
+    background-color: #293241;
+    color: white;
+    margin-top: 2rem;
+}
+.button {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    background-color: #3d5a80;
+    color: white;
+    border-radius: 4px;
+    text-decoration: none;
+}
+.button:hover {
+    background-color: #98c1d9;
+    color: #293241;
+}

--- a/index.html
+++ b/index.html
@@ -1,39 +1,30 @@
 <!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <title>My Resume</title>
-    </head>
-
-    <body>
-        <img src="./Pictures/431988660_1593142338114975_5102430991153926526_n.jpg" alt="picture of myself" height="300"> 
-        
-        <h1>Summary</h1>
-        <p>Greetings, I'm Joseph Mugwiza, a fourth-year medical student at VUB in Brussels, passionately dedicated to my pursuit of becoming a doctor. Alongside my studies, I'm delving into the realm of website development with the goal of creating my own project. </p>
-        
-        <h1>Education</h1>
-        <ul> 
-            <li>Secundary school 2014-2020: Math and Science at SMC Lede</li>
-            <li>B.Sc Medicine 2020-2023: UGent</li>
-            <li>M.Sc Medicine 2023-2026: VUB</li>
-        </ul>
-
-        <h1>Work experience</h1>
-        <ul>
-            <li>Student job at Volvo Cars Gent</li>
-        </ul>
-
-        <h1>Skills</h1>
-        <ul>
-            <li>I know English, Dutch and French</li>
-            <li>As a novice in HTML, I am actively engaged in learning CSS, JavaScript, and other programming languages with the aim of achieving proficiency in these areas.</li>
-        </ul>
-
-        <a href="./Pages/contact.html">Contact</a>
-        <a href="./Pages/hobbies.html">Hobbies</a>
-
-        <footer>
-            <small>Copyright © 2024 Joseph Mugwiza Resume. All Rights Reserved.</small>
-        </footer>
-    </body>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FutureMed</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <header>
+        <h1>FutureMed</h1>
+        <nav>
+            <a href="index.html">Home</a>
+            <a href="Pages/training.html">Training</a>
+            <a href="Pages/exam.html">Exammodus</a>
+            <a href="Pages/progress.html">Voortgang</a>
+            <a href="Pages/signup.html">Aanmelden</a>
+        </nav>
+    </header>
+    <main>
+        <h2>Welkom bij FutureMed</h2>
+        <p>FutureMed helpt je voorbereiden op het toelatingsexamen geneeskunde, tandheelkunde en diergeneeskunde in Vlaanderen. Registreer gratis en probeer het platform één week uit. Daarna kost zes maanden toegang 60 euro.</p>
+        <p>Ik ben een vijfdejaars geneeskundestudent en behaalde in 2020 een score van 207/240. Mijn ervaring deel ik graag om jou te helpen slagen.</p>
+        <a class="button" href="Pages/signup.html">Maak een account</a>
+    </main>
+    <footer>
+        &copy; 2024 FutureMed
+    </footer>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- overhaul landing page as a simple FutureMed demo
- add Dutch content describing the idea
- create new pages for training, exam mode, progress and signup
- style pages with a small CSS file

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685db1fe32dc83249e6bbd72b19ece7e