### PR TITLE
Add FutureMed demo site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# html-MyResume
+# FutureMed
+
+Dit project bevat een eenvoudige demonstratie website in HTML, CSS en JavaScript waarmee studenten in Vlaanderen zich kunnen voorbereiden op het toelatingsexamen geneeskunde, tandheelkunde en diergeneeskunde.
+
+Open `index.html` in een webbrowser om de site lokaal te bekijken. De website bevat:
+
+- Een week gratis toegang (gesimuleerd via lokale opslag)
+- Training modus met onmiddellijke feedback
+- Exam modus met timer en eenvoudige rekenmachine
+- Een pagina om de voortgang te bekijken
+
+Alle data wordt enkel in de browser opgeslagen (er is geen echte server of betalingsfunctie).

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,45 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f9f9f9;
+}
+
+header {
+    background-color: #006699;
+    color: white;
+    padding: 20px;
+    text-align: center;
+}
+
+nav {
+    background-color: #003d4c;
+    padding: 10px;
+}
+
+nav a {
+    color: white;
+    margin: 0 10px;
+    text-decoration: none;
+}
+
+main {
+    padding: 20px;
+}
+
+button {
+    background-color: #006699;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    cursor: pointer;
+    margin-top: 10px;
+}
+
+.progress {
+    margin-top: 20px;
+}
+
+.calculator input {
+    width: 40px;
+}

--- a/exam.html
+++ b/exam.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <title>FutureMed - Exam Modus</title>
+    <link rel="stylesheet" href="css/style.css">
+    <script src="js/exam.js" defer></script>
+</head>
+<body>
+    <header>
+        <h1>Exam modus</h1>
+    </header>
+    <nav>
+        <a href="index.html">Home</a>
+        <a href="training.html">Training</a>
+        <a href="progress.html">Voortgang</a>
+    </nav>
+    <main>
+        <div>Tijd resterend: <span id="timer">15:00</span></div>
+        <div id="exam-question"></div>
+        <div id="exam-options"></div>
+        <button onclick="volgende()">Volgende</button>
+        <div class="calculator">
+            <h3>Eenvoudige rekenmachine</h3>
+            <input id="calc-a" type="number"> 
+            <select id="calc-op">
+                <option value="+">+</option>
+                <option value="-">-</option>
+                <option value="*">*</option>
+                <option value="/">/</option>
+            </select>
+            <input id="calc-b" type="number">
+            <button onclick="calculate()">=</button>
+            <input id="calc-result" type="number" readonly>
+        </div>
+    </main>
+    <footer>
+        <small>FutureMed staat los van het officiële toelatingsexamenplatform.</small>
+    </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,39 +1,30 @@
 <!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <title>My Resume</title>
-    </head>
-
-    <body>
-        <img src="./Pictures/431988660_1593142338114975_5102430991153926526_n.jpg" alt="picture of myself" height="300"> 
-        
-        <h1>Summary</h1>
-        <p>Greetings, I'm Joseph Mugwiza, a fourth-year medical student at VUB in Brussels, passionately dedicated to my pursuit of becoming a doctor. Alongside my studies, I'm delving into the realm of website development with the goal of creating my own project. </p>
-        
-        <h1>Education</h1>
-        <ul> 
-            <li>Secundary school 2014-2020: Math and Science at SMC Lede</li>
-            <li>B.Sc Medicine 2020-2023: UGent</li>
-            <li>M.Sc Medicine 2023-2026: VUB</li>
-        </ul>
-
-        <h1>Work experience</h1>
-        <ul>
-            <li>Student job at Volvo Cars Gent</li>
-        </ul>
-
-        <h1>Skills</h1>
-        <ul>
-            <li>I know English, Dutch and French</li>
-            <li>As a novice in HTML, I am actively engaged in learning CSS, JavaScript, and other programming languages with the aim of achieving proficiency in these areas.</li>
-        </ul>
-
-        <a href="./Pages/contact.html">Contact</a>
-        <a href="./Pages/hobbies.html">Hobbies</a>
-
-        <footer>
-            <small>Copyright © 2024 Joseph Mugwiza Resume. All Rights Reserved.</small>
-        </footer>
-    </body>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <title>FutureMed</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <header>
+        <h1>FutureMed</h1>
+        <p>Voorbereiding voor toelatingsexamen geneeskunde, tandheelkunde en diergeneeskunde</p>
+    </header>
+    <nav>
+        <a href="index.html">Home</a>
+        <a href="login.html">Aanmelden</a>
+        <a href="training.html">Training</a>
+        <a href="exam.html">Exam modus</a>
+        <a href="progress.html">Voortgang</a>
+    </nav>
+    <main>
+        <h2>Welkom!</h2>
+        <p>FutureMed biedt een week gratis toegang. Daarna kost een abonnement 60 euro voor 6 maanden.</p>
+        <p>Ik ben een vijfdejaars geneeskundestudent en behaalde in 2020 een score van 207/240 op het toelatingsexamen.</p>
+        <p>Maak een account aan, probeer training of examenmodus en volg je voortgang.</p>
+    </main>
+    <footer>
+        <small>Deze website is niet officieel verbonden met de Vlaamse overheid.</small>
+    </footer>
+</body>
 </html>

--- a/js/exam.js
+++ b/js/exam.js
@@ -1,0 +1,99 @@
+const examVragen = [
+    {
+        vraag: 'Wat is 5 * 3?',
+        opties: ['8', '15', '20', '18'],
+        juist: 1
+    },
+    {
+        vraag: 'Hoeveel provincies heeft Vlaanderen?',
+        opties: ['4', '5', '6', '7'],
+        juist: 1
+    }
+];
+let examIndex = 0;
+let antwoorden = [];
+let timer;
+
+function startExam() {
+    examIndex = 0;
+    antwoorden = new Array(examVragen.length).fill(null);
+    toonExamVraag();
+    startTimer(15 * 60); // 15 minuten
+}
+
+function startTimer(seconden) {
+    const timerSpan = document.getElementById('timer');
+    timer = setInterval(() => {
+        if (seconden <= 0) {
+            clearInterval(timer);
+            eindeExam();
+        } else {
+            seconden--;
+            const min = Math.floor(seconden / 60);
+            const sec = seconden % 60;
+            timerSpan.innerText = `${min}:${sec.toString().padStart(2,'0')}`;
+        }
+    }, 1000);
+}
+
+function toonExamVraag() {
+    const v = examVragen[examIndex];
+    document.getElementById('exam-question').innerText = v.vraag;
+    const opts = document.getElementById('exam-options');
+    opts.innerHTML = '';
+    v.opties.forEach((opt, i) => {
+        const label = document.createElement('label');
+        const radio = document.createElement('input');
+        radio.type = 'radio';
+        radio.name = 'antwoord';
+        radio.value = i;
+        if (antwoorden[examIndex] === i) radio.checked = true;
+        label.appendChild(radio);
+        label.append(opt);
+        opts.appendChild(label);
+        opts.appendChild(document.createElement('br'));
+    });
+}
+
+function volgende() {
+    const geselecteerd = document.querySelector('input[name="antwoord"]:checked');
+    if (geselecteerd) {
+        antwoorden[examIndex] = parseInt(geselecteerd.value);
+    }
+    if (examIndex < examVragen.length - 1) {
+        examIndex++;
+        toonExamVraag();
+    } else {
+        eindeExam();
+    }
+}
+
+function eindeExam() {
+    clearInterval(timer);
+    let correct = 0;
+    examVragen.forEach((v, i) => {
+        if (antwoorden[i] === v.juist) correct++;
+    });
+    alert('Exam afgewerkt. Score: ' + correct + '/' + examVragen.length);
+    let stats = JSON.parse(localStorage.getItem('fm_progress')) || {correct:0,total:0};
+    stats.correct += correct;
+    stats.total += examVragen.length;
+    localStorage.setItem('fm_progress', JSON.stringify(stats));
+    window.location.href = 'progress.html';
+}
+
+function calculate() {
+    const a = parseFloat(document.getElementById('calc-a').value);
+    const b = parseFloat(document.getElementById('calc-b').value);
+    const op = document.getElementById('calc-op').value;
+    let result = 0;
+    if (op === '+') result = a + b;
+    if (op === '-') result = a - b;
+    if (op === '*') result = a * b;
+    if (op === '/') result = a / b;
+    document.getElementById('calc-result').value = result;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    startExam();
+});

--- a/js/login.js
+++ b/js/login.js
@@ -1,0 +1,20 @@
+function signup() {
+    const username = document.getElementById('username').value;
+    const password = document.getElementById('password').value;
+    if (username && password) {
+        localStorage.setItem('fm_user', JSON.stringify({username, password, trialStart: Date.now()}));
+        alert('Account aangemaakt. Log nu in.');
+    }
+}
+
+function login() {
+    const username = document.getElementById('username').value;
+    const password = document.getElementById('password').value;
+    const stored = JSON.parse(localStorage.getItem('fm_user'));
+    if (stored && stored.username === username && stored.password === password) {
+        sessionStorage.setItem('fm_logged_in', 'true');
+        window.location.href = 'training.html';
+    } else {
+        alert('Ongeldige login');
+    }
+}

--- a/js/progress.js
+++ b/js/progress.js
@@ -1,0 +1,7 @@
+function toonProgress() {
+    const stats = JSON.parse(localStorage.getItem('fm_progress')) || {correct:0,total:0};
+    const percent = stats.total ? Math.round((stats.correct / stats.total) * 100) : 0;
+    document.getElementById('progress-info').innerText = `Totaal juist: ${stats.correct} van ${stats.total} vragen (${percent}%)`;
+}
+
+document.addEventListener('DOMContentLoaded', toonProgress);

--- a/js/training.js
+++ b/js/training.js
@@ -1,0 +1,49 @@
+const vragen = [
+    {
+        vraag: 'Wat is 2 + 2?',
+        opties: ['3', '4', '5', '6'],
+        juist: 1
+    },
+    {
+        vraag: 'Wat is de hoofdstad van Belgi\u00eb?',
+        opties: ['Antwerpen', 'Gent', 'Brussel', 'Luik'],
+        juist: 2
+    }
+];
+let index = 0;
+let correct = 0;
+
+function toonVraag() {
+    if (index >= vragen.length) {
+        alert('Training voltooid. Juist: ' + correct + '/' + vragen.length);
+        let stats = JSON.parse(localStorage.getItem('fm_progress')) || {correct:0,total:0};
+        stats.correct += correct;
+        stats.total += vragen.length;
+        localStorage.setItem('fm_progress', JSON.stringify(stats));
+        return;
+    }
+    const v = vragen[index];
+    document.getElementById('question').innerText = v.vraag;
+    const optionsDiv = document.getElementById('options');
+    optionsDiv.innerHTML = '';
+    v.opties.forEach((opt, i) => {
+        const btn = document.createElement('button');
+        btn.innerText = opt;
+        btn.onclick = () => antwoord(i);
+        optionsDiv.appendChild(btn);
+    });
+}
+
+function antwoord(i) {
+    const v = vragen[index];
+    if (i === v.juist) {
+        alert('Correct!');
+        correct++;
+    } else {
+        alert('Fout. Het juiste antwoord is ' + v.opties[v.juist]);
+    }
+    index++;
+    toonVraag();
+}
+
+document.addEventListener('DOMContentLoaded', toonVraag);

--- a/login.html
+++ b/login.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <title>FutureMed - Aanmelden</title>
+    <link rel="stylesheet" href="css/style.css">
+    <script src="js/login.js" defer></script>
+</head>
+<body>
+    <header>
+        <h1>Aanmelden</h1>
+    </header>
+    <nav>
+        <a href="index.html">Home</a>
+    </nav>
+    <main>
+        <label>Gebruikersnaam: <input id="username" type="text"></label><br>
+        <label>Wachtwoord: <input id="password" type="password"></label><br>
+        <button onclick="login()">Inloggen</button>
+        <button onclick="signup()">Account aanmaken</button>
+    </main>
+    <footer>
+        <small>FutureMed staat los van het officiële toelatingsexamenplatform.</small>
+    </footer>
+</body>
+</html>

--- a/progress.html
+++ b/progress.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <title>FutureMed - Voortgang</title>
+    <link rel="stylesheet" href="css/style.css">
+    <script src="js/progress.js" defer></script>
+</head>
+<body>
+    <header>
+        <h1>Voortgang</h1>
+    </header>
+    <nav>
+        <a href="index.html">Home</a>
+        <a href="training.html">Training</a>
+        <a href="exam.html">Exam</a>
+    </nav>
+    <main>
+        <div id="progress-info" class="progress"></div>
+    </main>
+    <footer>
+        <small>FutureMed staat los van het officiële toelatingsexamenplatform.</small>
+    </footer>
+</body>
+</html>

--- a/resume.html
+++ b/resume.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>My Resume</title>
+    </head>
+
+    <body>
+        <img src="./Pictures/431988660_1593142338114975_5102430991153926526_n.jpg" alt="picture of myself" height="300"> 
+        
+        <h1>Summary</h1>
+        <p>Greetings, I'm Joseph Mugwiza, a fourth-year medical student at VUB in Brussels, passionately dedicated to my pursuit of becoming a doctor. Alongside my studies, I'm delving into the realm of website development with the goal of creating my own project. </p>
+        
+        <h1>Education</h1>
+        <ul> 
+            <li>Secundary school 2014-2020: Math and Science at SMC Lede</li>
+            <li>B.Sc Medicine 2020-2023: UGent</li>
+            <li>M.Sc Medicine 2023-2026: VUB</li>
+        </ul>
+
+        <h1>Work experience</h1>
+        <ul>
+            <li>Student job at Volvo Cars Gent</li>
+        </ul>
+
+        <h1>Skills</h1>
+        <ul>
+            <li>I know English, Dutch and French</li>
+            <li>As a novice in HTML, I am actively engaged in learning CSS, JavaScript, and other programming languages with the aim of achieving proficiency in these areas.</li>
+        </ul>
+
+        <a href="./Pages/contact.html">Contact</a>
+        <a href="./Pages/hobbies.html">Hobbies</a>
+
+        <footer>
+            <small>Copyright © 2024 Joseph Mugwiza Resume. All Rights Reserved.</small>
+        </footer>
+    </body>
+</html>

--- a/training.html
+++ b/training.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <title>FutureMed - Training</title>
+    <link rel="stylesheet" href="css/style.css">
+    <script src="js/training.js" defer></script>
+</head>
+<body>
+    <header>
+        <h1>Training modus</h1>
+    </header>
+    <nav>
+        <a href="index.html">Home</a>
+        <a href="exam.html">Exam</a>
+        <a href="progress.html">Voortgang</a>
+    </nav>
+    <main>
+        <div id="question"></div>
+        <div id="options"></div>
+    </main>
+    <footer>
+        <small>FutureMed staat los van het officiële toelatingsexamenplatform.</small>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build FutureMed demo site
- add login, training, exam and progress pages
- implement simple calculator and progress tracking
- mention 7-day trial and subscription price
- document project in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685db1fe32dc83249e6bbd72b19ece7e